### PR TITLE
Setup initial CI and build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  GO_VERSION: '1.17'
+  DOCKER_BUILDX_VERSION: 'v0.4.2'
+
+jobs:
+  ci:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: ${{ env.DOCKER_BUILDX_VERSION }}
+          install: true
+      
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      # NOTE(hasheddan): make build currently includes unit tests target as a
+      # prerequisite.
+      - name: Build Binaries
+        run: make build
+
+      - name: Publish Artifacts to GitHub
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-# binaries
+# builds
 
-distribution
-kubectl-k8scr
+build

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 SHELL := /bin/bash
 
 build: test
-	@CGO_ENABLED=0 go build -o kubectl-k8scr ./cmd/k8scr
-	@CGO_ENABLED=0 go build -o distribution ./cmd/k8scr-distribution
+	@CGO_ENABLED=0 go build -o ./build/kubectl-k8scr ./cmd/k8scr
+	@CGO_ENABLED=0 go build -o ./build/distribution ./cmd/k8scr-distribution
 
 image:
 	@docker build . -f distribution.Dockerfile -t hasheddan/k8scr-distribution:latest --load

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,10 @@ image:
 
 all: build image
 
-lint:
-	@$(LINT) run
-
 tidy:
 	@go mod tidy
 
 test:
 	@go test -v ./...
 
-.PHONY: tidy lint clean build image all
+.PHONY: tidy clean build image all

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash
 
 build: test
-	@CGO_ENABLED=0 go build -o ./build/kubectl-k8scr ./cmd/k8scr
+	@CGO_ENABLED=0 go build -o ./build/k8scr ./cmd/k8scr
 	@CGO_ENABLED=0 go build -o ./build/distribution ./cmd/k8scr-distribution
 
 image:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A `kubectl` plugin for pushing OCI images through the Kubernetes API server.
   <img src="docs/media/k8scr.svg">
 </p>
 
-1. Build `kubectl-k8scr`
+1. Build `k8scr`
 
 ```
 make build
@@ -18,7 +18,7 @@ make build
 2. Move to location in `PATH`
 
 ```
-sudo mv ./kubectl-k8scr /usr/local/bin
+sudo mv ./build/k8scr /usr/local/bin/kubectl-k8scr
 ```
 
 3. Deploy simple in-memory registry into cluster

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hasheddan/k8scr
 
-go 1.16
+go 1.17
 
 require (
 	github.com/alecthomas/kong v0.2.16
@@ -9,4 +9,59 @@ require (
 	k8s.io/apimachinery v0.21.1
 	k8s.io/client-go v0.21.1
 	k8s.io/kubectl v0.21.1
+)
+
+require (
+	cloud.google.com/go v0.57.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.11.12 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.5 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/Microsoft/go-winio v0.4.14 // indirect
+	github.com/containerd/containerd v1.3.0 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.4.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7 // indirect
+	github.com/docker/docker-credential-helpers v0.6.3 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/googleapis/gnostic v0.4.1 // indirect
+	github.com/imdario/mergo v0.3.5 // indirect
+	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sirupsen/logrus v1.6.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 // indirect
+	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a // indirect
+	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
+	golang.org/x/text v0.3.4 // indirect
+	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece // indirect
+	google.golang.org/grpc v1.29.1 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/klog/v2 v2.8.0 // indirect
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.1.0 // indirect
+	sigs.k8s.io/yaml v1.2.0 // indirect
 )


### PR DESCRIPTION
Sets up an initial CI and build pipeline. Artifacts are uploaded alongside the action run after build. Does not yet support building the distribution image or any release activities.